### PR TITLE
 Adding a matrix to circle config so that tests for python versions in future can be added easily

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 variables:
   update_conda: &update_conda
@@ -9,7 +9,7 @@ variables:
   create_conda_env: &create_conda_env
     run:
       name: create conda env
-      command: conda create -n kipoi-dev python=3.10
+      command: conda create -n kipoi-dev python=<< parameters.python-version >>
 
   install_kipoi_utils: &install_kipoi_utils
     run:
@@ -69,7 +69,10 @@ variables:
 
 jobs:
 
-  test-py310:
+  test:
+    parameters:
+      python-version:
+        type: string
     docker:
       - image: continuumio/miniconda3:latest
     working_directory: ~/repo
@@ -84,6 +87,10 @@ jobs:
       - *store_test_artifacts
 
   test-deploy-pypi:
+    parameters:
+      python-version:
+        type: string
+        default: "3.9"
     docker:
       - image: continuumio/miniconda3:latest
     working_directory: ~/repo
@@ -110,6 +117,10 @@ jobs:
             python -c "import kipoi_utils; print(kipoi_utils.__version__)"
     
   productive-deploy-pypi:
+    parameters:
+      python-version:
+        type: string
+        default: "3.9"
     docker:
       - image: continuumio/miniconda3:latest
     working_directory: ~/repo
@@ -138,26 +149,28 @@ jobs:
             python -c "import kipoi_utils; print(kipoi_utils.__version__)"          
 
 workflows:
-  version: 2
+  version: 2.1
 
   test:
     jobs:
-      - test-py310
-  test-n-deploy:
-    jobs:
-      - test-py310
+      - test:
+          matrix:
+            parameters:
+              python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
       - test-deploy-pypi:
           requires:
-            - test-py310
+            - test
           filters:
             branches:
               only:
                 - add-pypi-deployment
+                - add-more-python-versions
       - productive-deploy-pypi:
           requires:
-            - test-py310
+            - test
           filters:
             branches:
               only:
                 - master
+                - add-more-python-versions
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,6 @@ workflows:
             branches:
               only:
                 - add-pypi-deployment
-                - add-more-python-versions
       - productive-deploy-pypi:
           requires:
             - test
@@ -172,5 +171,3 @@ workflows:
             branches:
               only:
                 - master
-                - add-more-python-versions
-


### PR DESCRIPTION
Just add/remove version number [here]()

A `__init__.py` file is added to `tests` to accumulate coverage report.

Also fixed errors with coverall.io. The steps are as follows - 

1. Go to coveralls.io and create an account.
2. Use `ADD REPOS` from menu to add your choice of repo
3. Go back to REPOS and access your chosen repo's settings
4. Copy `REPO TOKEN`
5. Go to the CircleCI and the project settings of the repo in question
6. Add the copied token as an environment variable named `COVERALLS_REPO_TOKEN`